### PR TITLE
feat: dockerfile:port 8080 exposed

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -2,4 +2,6 @@ FROM go:1.20.2
 
 WORKDIR /app
 
+EXPOSE 8080
+
 CMD ["go", "run", "main.go"]


### PR DESCRIPTION
## Description

<!-- 
Please do not leave this blank 
This PR [adds/removes/fixes/replaces] the [feature/bug/etc]. 
-->

This PR exposes port 8080 in the Dockerfile, allowing external access to the container's process listening on that port.

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build
- [ ] ⏩ Revert

## Related Tickets & Documents
<!-- 
Please use this format link issue numbers: Fixes #123
https://docs.github.com/en/free-pro-team@latest/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword 
-->



## Mobile & Desktop Screenshots/Recordings

<!-- Visual changes require screenshots -->



## Steps to QA
<!-- 
Please provide some steps for the reviewer to test your change. If you have wrote tests, you can mention that here instead.

1. Click a link
2. Do this thing
3. Validate you see the thing working
-->

1. Build the image using the updated Dockerfile.
2. Run the container and verify it starts successfully.

## Added to documentation?

- [ ] 📜 README.md
- [ ] 📓 docs.example.com
- [x] 🙅 no documentation needed
